### PR TITLE
feat(skills): add Skills core models, registry, and docs baseline

### DIFF
--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,101 @@
+# DECISIONS.md
+
+**Project:** Multi-Agent RAG Refactor Bot  
+**Version:** v0.1.1 (Closing All Gaps)  
+**File created:** February 18, 2026  
+**Last updated:** [YYYY-MM-DD]  
+**Owner:** [Your Name / Developer]
+
+This file records **binding architectural and implementation decisions** made before starting the gap-closing work.  
+All changes in the `feature/close-all-gaps-v0.1.1` branch must align with the decisions recorded here.
+
+---
+
+## 1. Skip Behavior
+
+**Decision required:** What to do with the currently unreachable `skip_node`?
+
+**Options considered:**
+- **A (Recommended):** Remove `skip_node` entirely (clean dead code, simplify graph)
+- **B:** Wire `skip_node` into the graph with explicit conditional routing
+
+**Chosen decision:** [A / B]  
+**Rationale:**  
+[Write 1–3 sentences why this was chosen]
+
+**Implementation impact:**  
+[Will be filled after implementation – e.g. “skip_node and all references deleted”]
+
+---
+
+## 2. No-Test-Runner Mode Policy
+
+**Decision required:** How should the pipeline behave when no test runner (`vitest`, `npm test`, etc.) is detected?
+
+**Options considered:**
+- **A (Recommended – Conservative):** Default `passed=False` + `runner_available=False` → forces ABORT unless `--allow-no-runner-pass` flag is used
+- **B:** Allow LLM fallback to return `passed=True` by default (riskier)
+
+**Chosen decision:** [A / B]  
+**Rationale:**  
+[Write 1–3 sentences]
+
+**Flag behavior (if A chosen):**
+- `--allow-no-runner-pass` (default: false)
+- When enabled + Anthropic key present → LLM fallback with `low_trust_pass=True` flag in `TestReport`
+
+---
+
+## 3. Partial Rollback Support
+
+**Decision required:** Should we support partial/subtree rollback on failed tasks?
+
+**Options considered:**
+- **A (Recommended):** Remove all references to partial rollback (PRD, docs, helpers, comments)
+- **B:** Implement simple subtree rollback inside `apply_node` / recovery helpers
+
+**Chosen decision:** [A / B]  
+**Rationale:**  
+[Write 1–3 sentences]
+
+---
+
+## 4. Abort Threshold Lockdown
+
+**Decision required:** Standardize the test pass-rate abort threshold
+
+**Options considered:**
+- Lock to exactly `0.85` (0.85) everywhere (matches current code)
+- Keep flexibility / different values
+
+**Chosen decision:**  
+**Final value:** `0.85` (85%)  
+
+**Files that must be updated:**  
+- `orchestrator/graph.py` (or wherever `compute_test_pass_rate` is used)
+- All documentation (PRD, design spec, README)
+
+---
+
+## 5. Additional Decisions (if any)
+
+**Decision 5.1:** [Title]  
+**Chosen:**  
+**Rationale:**  
+
+---
+
+## Sign-off
+
+I confirm that the decisions above are final and will be followed during implementation.
+
+**Developer signature:** _______________________________  
+**Date:** _______________________________
+
+---
+
+**Next step:** Commit this file **before** any code changes in the feature branch.
+
+```bash
+git add docs/DECISIONS.md
+git commit -m "docs: record binding decisions for v0.1.1 gap closure"

--- a/docs/SKILLS_ARCHITECTURE.md
+++ b/docs/SKILLS_ARCHITECTURE.md
@@ -1,0 +1,65 @@
+# Skills Architecture
+
+**Version:** 1.0 (for v0.2.0+)  
+**Date:** February 18, 2026  
+**Status:** Ready for implementation after v0.1.1
+
+## Overview
+This document defines the **Skills-based architecture** that replaces the legacy `rules/` directory and hard-coded React best practices.
+
+A **Skill** is a self-contained, versioned, reusable capability that extends the bot with:
+- Detection logic (`applies_to`)
+- Rules (for Auditor)
+- Prompt context (for Planner + Executor)
+- Human-readable docs (SKILL.md)
+- Agent-specific instructions (AGENTS.md)
+
+This design is **100% compatible** with Vercel’s official Agent Skills standard (January 2026).
+
+## Directory Structure
+
+```text
+src/refactor_bot/
+├── skills/
+│   ├── __init__.py
+│   ├── base.py
+│   ├── registry.py
+│   ├── manager.py
+│   └── vercel_react_best_practices/
+│       ├── __init__.py
+│       ├── skill.py
+│       ├── rules.py
+│       ├── SKILL.md
+│       ├── AGENTS.md
+│       └── metadata.json
+├── models/
+│   └── skill_models.py
+└── ...
+```
+
+## Core Interfaces
+
+### Skill Protocol (`skills/base.py`)
+
+(See code below)
+
+## Integration Points
+
+1. RepoIndexer → `skill_registry.auto_activate(...)`
+2. CLI → `--skills` flag
+3. Planner / Executor → `registry.get_prompt_context_for_all_active()`
+4. ConsistencyAuditor → `registry.get_all_rules()`
+
+## Migration Path
+
+- Move existing `react_rules.py` content into the new Vercel skill folder
+- Keep legacy `rules/` shim for one release
+
+## Usage
+
+```bash
+python -m refactor_bot.cli "Convert class components to hooks" ./my-app --skills vercel-react-best-practices
+```
+
+Full implementation guide inside this file after you add the code.
+

--- a/docs/Skills Architecture.md
+++ b/docs/Skills Architecture.md
@@ -1,0 +1,48 @@
+# Skills Architecture
+
+**Version:** 1.0 (for v0.2.0+)  
+**Date:** February 18, 2026  
+**Status:** Proposed → Implement after v0.1.1
+
+## Overview
+
+This document defines the **Skills-based architecture** that replaces the legacy `rules/` directory and hard-coded React best practices.
+
+A **Skill** is a self-contained, versioned, reusable capability that extends the bot with:
+- Detection logic (`applies_to`)
+- Rules (for Auditor)
+- Prompt context (for Planner + Executor)
+- Human-readable docs (SKILL.md)
+- Agent-specific instructions (AGENTS.md)
+
+This design is **100% compatible** with the official [Vercel Agent Skills standard](https://github.com/vercel-labs/agent-skills) released January 2026 (react-best-practices, composition-patterns, etc.).
+
+## Why Skills?
+
+- Matches the 2026 industry standard used by Claude Code, Cursor, Opencode, Codex.
+- Enables progressive disclosure (load only needed context → token efficient).
+- Community-contributable (drop in a new skill folder).
+- Perfectly aligns with future `LanguagePack` system.
+- Turns “some extended Vercel React support” into first-class, updatable skills.
+- CLI control: `--skills vercel-react-best-practices,security,typescript-strict`
+
+## Directory Structure
+
+```text
+src/refactor_bot/
+├── skills/
+│   ├── __init__.py
+│   ├── base.py                 # Skill Protocol + base classes
+│   ├── registry.py             # SkillRegistry (singleton)
+│   ├── manager.py              # SkillManager (orchestrator integration)
+│   └── vercel_react_best_practices/   # First official skill
+│       ├── __init__.py
+│       ├── skill.py            # Skill implementation
+│       ├── rules.py            # RefactorRule list
+│       ├── SKILL.md            # Human docs (verbatim from Vercel)
+│       ├── AGENTS.md           # LLM context (verbatim from Vercel)
+│       └── metadata.json       # Standard Vercel metadata
+├── models/
+│   └── skill_models.py         # Pydantic models (added)
+├── rules/                      # Legacy – will be deprecated after migration
+└── ...

--- a/src/refactor_bot/models/__init__.py
+++ b/src/refactor_bot/models/__init__.py
@@ -18,8 +18,11 @@ from refactor_bot.models.schemas import (
     SymbolInfo,
 )
 from refactor_bot.models.task_models import TaskNode, TaskStatus
+from refactor_bot.models.skill_models import RefactorRule, SkillMetadata
 
 __all__ = [
+    "RefactorRule",
+    "SkillMetadata",
     "AuditFinding",
     "AuditReport",
     "BreakingChange",

--- a/src/refactor_bot/models/report_models.py
+++ b/src/refactor_bot/models/report_models.py
@@ -69,3 +69,4 @@ class TestReport(BaseModel):
     runner_available: bool = True
     llm_analysis: str | None = None
     tested_at: datetime = Field(default_factory=datetime.now)
+    low_trust_pass: bool = False

--- a/src/refactor_bot/models/skill_models.py
+++ b/src/refactor_bot/models/skill_models.py
@@ -1,0 +1,25 @@
+from typing import List, Literal
+
+from pydantic import BaseModel
+
+from refactor_bot.rules.rule_engine import ReactRule
+
+
+ImpactLevel = Literal["CRITICAL", "HIGH", "MEDIUM", "LOW"]
+
+
+class SkillMetadata(BaseModel):
+    name: str
+    version: str
+    description: str
+    author: str = "refactor-bot"
+    license: str = "MIT"
+    impact_levels: List[ImpactLevel]
+    categories: List[str]
+    triggers: List[str]
+
+
+class RefactorRule(ReactRule):
+    """Rule model shared by skills and legacy rule systems."""
+
+    pass

--- a/src/refactor_bot/skills/__init__.py
+++ b/src/refactor_bot/skills/__init__.py
@@ -1,0 +1,5 @@
+from .registry import registry
+from .base import Skill
+
+__all__ = ["registry", "Skill"]
+

--- a/src/refactor_bot/skills/base.py
+++ b/src/refactor_bot/skills/base.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from typing import Any, Protocol, runtime_checkable
+from ..models.skill_models import SkillMetadata
+from ..models.task_models import TaskNode
+from ..models.skill_models import RefactorRule
+
+
+@runtime_checkable
+class Skill(Protocol):
+    """Core Skill Protocol – matches Vercel Agent Skills 2026 standard."""
+
+    metadata: SkillMetadata
+
+    def applies_to(
+        self,
+        repo_index: Any,
+        directive: str | None = None,
+    ) -> bool:
+        """Return True if this skill should be active."""
+
+    def get_rules(self) -> list[RefactorRule]:
+        """Rules provided by this skill (used by Auditor)."""
+
+    def get_prompt_context(
+        self, directive: str, task: TaskNode | None = None
+    ) -> str:
+        """Full context string to inject into LLM prompts."""
+
+    def load_from_disk(self, skill_path: Path) -> None:
+        """Optional runtime load of SKILL.md / AGENTS.md."""

--- a/src/refactor_bot/skills/manager.py
+++ b/src/refactor_bot/skills/manager.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from .registry import registry
+# from ..languages.registry import registry as lang_registry  # will be added in Phase 2
+
+
+def activate_skills_for_repo(
+    repo_index,
+    directive: str | None = None,
+    selected_skill_names: list[str] | None = None,
+):
+    """Helper called from RepoIndexer / CLI."""
+    registry.register_from_package("vercel_react_best_practices")
+    if selected_skill_names:
+        registry.activate_by_name(selected_skill_names)
+    else:
+        registry.auto_activate(repo_index, directive)
+    return registry.get_active_skills()

--- a/src/refactor_bot/skills/registry.py
+++ b/src/refactor_bot/skills/registry.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING, Any, Dict, List
+
+from .base import Skill
+from ..models.skill_models import RefactorRule
+
+if TYPE_CHECKING:
+    from ..models.schemas import RepoIndex
+
+
+class SkillRegistry:
+    _instance = None
+    _skills: Dict[str, Skill] = {}
+    _active_skills: List[Skill] = []
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+        return cls._instance
+
+    @classmethod
+    def get_instance(cls) -> "SkillRegistry":
+        return cls()
+
+    def register(self, skill: Skill) -> None:
+        self._skills[skill.metadata.name] = skill
+
+    def register_from_package(self, package_name: str) -> None:
+        try:
+            module = importlib.import_module(f"refactor_bot.skills.{package_name}")
+            if hasattr(module, "skill"):
+                self.register(module.skill)
+        except Exception as e:
+            print(f"[SkillRegistry] Failed to register {package_name}: {e}")
+
+    def auto_activate(self, repo_index: "RepoIndex", directive: str | None = None) -> List[Skill]:
+        self._active_skills = [
+            s for s in self._skills.values() if s.applies_to(repo_index, directive)
+        ]
+        return self._active_skills
+
+    def activate_by_name(self, names: List[str]) -> None:
+        self._active_skills = [s for name, s in self._skills.items() if name in names]
+
+    def get_active_skills(self) -> List[Skill]:
+        return self._active_skills
+
+    def get_prompt_context_for_all_active(self, directive: str, task: Any = None) -> str:
+        return "\n\n".join(
+            s.get_prompt_context(directive, task) for s in self._active_skills
+        )
+
+    def get_all_rules(self) -> List["RefactorRule"]:
+        rules = []
+        for s in self._active_skills:
+            rules.extend(s.get_rules())
+        return rules
+
+
+registry = SkillRegistry.get_instance()

--- a/src/refactor_bot/skills/vercel_react_best_practices/AGENTS.md
+++ b/src/refactor_bot/skills/vercel_react_best_practices/AGENTS.md
@@ -1,0 +1,8 @@
+# React Best Practices for Agents
+
+**Vercel Engineering – January 2026**
+
+[Copy the full AGENTS.md content from the official Vercel repo here]
+
+This file contains the exact prompt context that will be injected into Planner and Executor.
+

--- a/src/refactor_bot/skills/vercel_react_best_practices/SKILL.md
+++ b/src/refactor_bot/skills/vercel_react_best_practices/SKILL.md
@@ -1,0 +1,9 @@
+# Vercel React Best Practices Skill
+
+**Version:** 1.0.0  
+**Source:** Official Vercel Agent Skills (January 2026)
+
+[Copy the full SKILL.md content from https://github.com/vercel-labs/agent-skills/tree/main/skills/react-best-practices/SKILL.md here]
+
+(For now you can leave this as a placeholder or paste the official file directly.)
+

--- a/src/refactor_bot/skills/vercel_react_best_practices/__init__.py
+++ b/src/refactor_bot/skills/vercel_react_best_practices/__init__.py
@@ -1,0 +1,4 @@
+from .skill import skill
+
+__all__ = ["skill"]
+

--- a/src/refactor_bot/skills/vercel_react_best_practices/metadata.json
+++ b/src/refactor_bot/skills/vercel_react_best_practices/metadata.json
@@ -1,0 +1,7 @@
+{
+  "version": "1.0.0",
+  "organization": "Vercel Engineering",
+  "date": "January 2026",
+  "abstract": "Comprehensive performance optimization guide for React and Next.js applications.",
+  "references": ["https://react.dev", "https://nextjs.org"]
+}

--- a/src/refactor_bot/skills/vercel_react_best_practices/rules.py
+++ b/src/refactor_bot/skills/vercel_react_best_practices/rules.py
@@ -1,0 +1,3 @@
+# Placeholder for parsed rules from SKILL.md
+# In next step we will auto-generate RefactorRule objects here
+

--- a/src/refactor_bot/skills/vercel_react_best_practices/skill.py
+++ b/src/refactor_bot/skills/vercel_react_best_practices/skill.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+
+from ...skills.base import Skill
+from ...models.skill_models import SkillMetadata
+from ...models.skill_models import RefactorRule
+
+
+class VercelReactBestPracticesSkill(Skill):
+    metadata = SkillMetadata(
+        name="vercel-react-best-practices",
+        version="1.0.0",
+        description="Official Vercel React & Next.js performance rules (57 rules, Jan 2026)",
+        author="vercel",
+        impact_levels=["CRITICAL", "HIGH", "MEDIUM", "LOW"],
+        categories=["performance", "react", "nextjs"],
+        triggers=["react", "nextjs", "performance"]
+    )
+
+    def applies_to(self, repo_index, directive=None) -> bool:
+        return getattr(repo_index, 'is_react_project', False) or "react" in (directive or "").lower()
+
+    def get_rules(self) -> list[RefactorRule]:
+        # Expand with rule parser in next step
+        return []  # placeholder
+
+    def get_prompt_context(self, directive: str, task=None) -> str:
+        ag_path = Path(__file__).parent / "AGENTS.md"
+        if ag_path.exists():
+            return ag_path.read_text(encoding="utf-8")
+        return "Vercel React Best Practices loaded."
+
+    def load_from_disk(self, skill_path: Path) -> None:
+        pass
+
+
+skill = VercelReactBestPracticesSkill()


### PR DESCRIPTION
## Summary
Introduce the Skills core platform scaffolding and baseline documentation for the v0.2.0+ architecture.

## Files Changed
- src/refactor_bot/models/skill_models.py
- src/refactor_bot/models/__init__.py
- src/refactor_bot/models/report_models.py
- src/refactor_bot/skills/base.py
- src/refactor_bot/skills/registry.py
- src/refactor_bot/skills/manager.py
- src/refactor_bot/skills/vercel_react_best_practices/__init__.py
- src/refactor_bot/skills/vercel_react_best_practices/skill.py
- src/refactor_bot/skills/vercel_react_best_practices/rules.py
- src/refactor_bot/skills/vercel_react_best_practices/SKILL.md
- src/refactor_bot/skills/vercel_react_best_practices/AGENTS.md
- src/refactor_bot/skills/vercel_react_best_practices/metadata.json
- docs/SKILLS_ARCHITECTURE.md
- docs/DECISIONS.md
- docs/Skills Architecture.md

## Testing Notes
- uv run pytest (or project test command)
- uv run python -m refactor_bot.cli --help
- rg "class Skill" src/refactor_bot/skills -n (smoke check for symbol availability)

## Risk List
1. High: rules.py is still a placeholder; rule runtime is not fully populated.
2. High: SKILL.md / AGENTS.md content may still be placeholder content in this PR.
3. Medium: New Skill protocol and model exports may require downstream type/import adjustments.
4. Medium: Behavior change in model shape if external consumers construct these models directly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the core Skills platform (protocol, models, registry, manager) and the first skill: vercel-react-best-practices, with baseline docs and exports. Also adds low_trust_pass to TestReport to support the planned no-test-runner fallback policy.

- **New Features**
  - Skill protocol and models (SkillMetadata, RefactorRule); registry singleton with auto activation and prompt context aggregation; manager helper to activate skills.
  - First skill: vercel-react-best-practices (metadata, AGENTS.md prompt context, SKILL.md, placeholder rules, metadata.json).
  - Updated exports in models and skills packages; TestReport now includes low_trust_pass.
  - Docs added: SKILLS_ARCHITECTURE.md and DECISIONS.md.

<sup>Written for commit ca1dbc2c8199fef309f2624237c779ae5592e323. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

