### PR TITLE
feat(skills): harden Vercel skill rule parser

### DIFF
--- a/src/refactor_bot/skills/vercel_react_best_practices/rules.py
+++ b/src/refactor_bot/skills/vercel_react_best_practices/rules.py
@@ -10,8 +10,28 @@ import re
 from refactor_bot.models.skill_models import RefactorRule
 from refactor_bot.rules.react_rules import REACT_RULES
 
-SECTION_HEADER_RE = re.compile(r"^###\s+\d+\.\s+(?P<section>.+?)\s*\((?P<priority>[^)]+)\)")
-RULE_ITEM_RE = re.compile(r"^- `(?P<rule_id>[^`]+)` - (?P<description>.*)$")
+SECTION_HEADER_RE = re.compile(
+    r"^#{1,6}\s+(?:\d+\.\s*)?(?P<section>.+?)\s*(?:\((?P<priority>[^)]+)\))?\s*$"
+)
+RULE_ITEM_RE = re.compile(
+    r"^[\t ]*(?:[-*+]|\d+[.)])\s+`(?P<rule_id>[^`]+)`\s*(?:[-–—:]\s*)?(?P<description>.*)$"
+)
+TABLE_ROW_RE = re.compile(
+    r"^\|?\s*`(?P<rule_id>[^`]+)`\s*\|\s*(?P<description>[^|]+)"
+)
+SECTION_PRIORITY_RE = re.compile(r"\b(CRITICAL|HIGH|MEDIUM|LOW)\b", re.IGNORECASE)
+
+
+def _normalize_priority(raw_priority: str) -> str:
+    """Clamp priority to known severities."""
+    match = SECTION_PRIORITY_RE.search(raw_priority or "")
+    if not match:
+        return "MEDIUM"
+    return match.group(1).upper()
+
+
+def _strip_numeric_prefix(section: str) -> str:
+    return re.sub(r"^\d+\.\s*", "", section).strip()
 
 
 def _parse_skill_catalog(skill_markdown_path: Path) -> Dict[str, Tuple[str, str, str]]:
@@ -20,60 +40,126 @@ def _parse_skill_catalog(skill_markdown_path: Path) -> Dict[str, Tuple[str, str,
     current_section = "General"
     current_priority = "MEDIUM"
 
+    if not skill_markdown_path.exists():
+        return rules
+
+    in_code_block = False
+
     with skill_markdown_path.open(encoding="utf-8") as fp:
         for raw_line in fp:
-            line = raw_line.strip()
+            line = raw_line.rstrip()
+
+            if line.strip().startswith("```"):
+                in_code_block = not in_code_block
+                continue
+            if in_code_block:
+                continue
+
+            line = line.strip()
+            if not line:
+                continue
 
             section_match = SECTION_HEADER_RE.match(line)
             if section_match:
-                current_section = section_match.group("section").strip()
-                current_priority = section_match.group("priority").strip()
+                current_section = _strip_numeric_prefix(section_match.group("section").strip())
+                current_priority = _normalize_priority(
+                    section_match.group("priority") or current_priority
+                )
                 continue
 
             rule_match = RULE_ITEM_RE.match(line)
-            if rule_match:
-                rule_id = rule_match.group("rule_id").strip()
-                description = rule_match.group("description").strip()
+            if not rule_match:
+                rule_match = TABLE_ROW_RE.match(line)
+            if not rule_match:
+                continue
+
+            rule_id = rule_match.group("rule_id").strip()
+            description = rule_match.group("description").strip()
+            if rule_id and not rule_id.startswith("#") and rule_id not in rules:
                 rules[rule_id] = (current_section, current_priority, description)
 
     return rules
 
 
-def get_rules(skill_markdown_path: Path) -> list[RefactorRule]:
-    """Load skill-backed React rules into shared `RefactorRule` format."""
-    catalog = _parse_skill_catalog(skill_markdown_path)
+def _normalize_rule(
+    rule_id: str,
+    category: str,
+    priority: str,
+    description: str,
+    template: RefactorRule | None = None,
+) -> RefactorRule:
+    if template is None:
+        return RefactorRule(
+            rule_id=rule_id,
+            category=category,
+            priority=_normalize_priority(priority),
+            description=(
+                f"{description} (placeholder guidance; complete pattern not available)"
+                if description
+                else "Placeholder guidance; complete pattern not available"
+            ).strip(),
+            incorrect_pattern="// TODO: add incorrect pattern",
+            correct_pattern="// TODO: add correct pattern",
+        )
+
+    merged_description = (
+        f"{description}\n\nLegacy guidance: {template.description}".strip()
+        if description
+        else template.description
+    )
+    return RefactorRule(
+        rule_id=rule_id,
+        category=template.category or category,
+        priority=_normalize_priority(template.priority or priority),
+        description=merged_description,
+        incorrect_pattern=template.incorrect_pattern,
+        correct_pattern=template.correct_pattern,
+    )
+
+
+def _build_rules(catalog: Dict[str, Tuple[str, str, str]]) -> list[RefactorRule]:
     if not catalog:
-        return []
+        return [
+            RefactorRule(
+                rule_id=rule.rule_id,
+                category=rule.category,
+                priority=rule.priority,
+                description=rule.description,
+                incorrect_pattern=rule.incorrect_pattern,
+                correct_pattern=rule.correct_pattern,
+            )
+            for rule in REACT_RULES
+        ]
 
     react_rule_index = {rule.rule_id: rule for rule in REACT_RULES}
     rules: list[RefactorRule] = []
 
     for rule_id, (category, priority, description) in catalog.items():
         template = react_rule_index.get(rule_id)
-        if not template:
-            rules.append(
+        rules.append(_normalize_rule(rule_id, category, priority, description, template))
+
+    return rules
+
+
+def _add_missing_rules_from_react(catalog_rules: list[RefactorRule]) -> list[RefactorRule]:
+    catalog_ids = {rule.rule_id for rule in catalog_rules}
+    for rule in REACT_RULES:
+        if rule.rule_id not in catalog_ids:
+            catalog_rules.append(
                 RefactorRule(
-                    rule_id=rule_id,
-                    category=category,
-                    priority=priority,
-                    description=f"{description} (pattern not shipped in code base)",
-                    incorrect_pattern=f"// TODO: add incorrect pattern for {rule_id}",
-                    correct_pattern=f"// TODO: add correct pattern for {rule_id}",
+                    rule_id=rule.rule_id,
+                    category=rule.category,
+                    priority=rule.priority,
+                    description=rule.description,
+                    incorrect_pattern=rule.incorrect_pattern,
+                    correct_pattern=rule.correct_pattern,
                 )
             )
-            continue
+    return catalog_rules
 
-        rules.append(
-            RefactorRule(
-                rule_id=rule_id,
-                category=template.category or category,
-                priority=template.priority or priority,
-                description=(
-                    f"{description}\n\n"
-                    f"Legacy guidance: {template.description}"
-                ).strip(),
-                incorrect_pattern=template.incorrect_pattern,
-                correct_pattern=template.correct_pattern,
-            )
-        )
-    return rules
+
+def get_rules(skill_markdown_path: Path) -> list[RefactorRule]:
+    """Load skill-backed React rules into shared `RefactorRule` format."""
+    catalog = _parse_skill_catalog(skill_markdown_path)
+    parsed_rules = _build_rules(catalog)
+    return _add_missing_rules_from_react(parsed_rules)


### PR DESCRIPTION
## Summary
Hardens Vercel skill rule parsing to production-safe behavior:
- Supports flexible SKILL.md formats (heading variations, bullet styles, table rows)
- Ignores rule IDs inside fenced code blocks
- Normalizes section and priority metadata
- Always returns complete React rule coverage by filling missing SKILL entries from `REACT_RULES`
- Adds fallback when SKILL.md parsing is incomplete/missing.

## Validation
- Updated tests in `tests/test_skills.py`
  - Added flexible markdown parser test coverage
  - Added fallback coverage test when SKILL.md placeholder/minimal content is present
- Existing parser fixture test remains and is preserved

## Risk
- Fallback currently fills unspecified rules from legacy `REACT_RULES` catalog; downstream behavior remains deterministic and complete by design.

## Issue
- Closes #17


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the Vercel skill rule parser to reliably read SKILL.md across formats and always return complete React rule coverage. Addresses Linear #17 with production-safe parsing and deterministic fallbacks.

- **New Features**
  - Accepts varied headings, list styles (bulleted/numbered), and table rows for rule entries.
  - Ignores rule-like text inside fenced code blocks.
  - Normalizes section names and clamps priority to CRITICAL/HIGH/MEDIUM/LOW.
  - Ensures full coverage by filling missing SKILL.md rules from REACT_RULES and falling back entirely when SKILL.md is missing or minimal.

<sup>Written for commit 501563b583bde01f93ae728b38a8feb1258a0a03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

