### PR TITLE
chore(skills): preserve downstream RefactorRule model compatibility

### DIFF
--- a/src/refactor_bot/models/report_models.py
+++ b/src/refactor_bot/models/report_models.py
@@ -70,3 +70,20 @@ class TestReport(BaseModel):
     llm_analysis: str | None = None
     tested_at: datetime = Field(default_factory=datetime.now)
     low_trust_pass: bool = False
+
+
+# Backward-compatible model exports for downstream integrations.
+from refactor_bot.models.skill_models import RefactorRule as SkillRefactorRule, SkillMetadata
+
+RefactorRule = SkillRefactorRule
+
+__all__ = [
+    "AuditFinding",
+    "AuditReport",
+    "BreakingChange",
+    "FindingSeverity",
+    "TestReport",
+    "TestRunResult",
+    "RefactorRule",
+    "SkillMetadata",
+]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -37,6 +37,17 @@ def test_vercel_rules_parser_reads_quick_reference(tmp_path: Path):
     assert parsed[0].category in {"Eliminating Waterfalls", "Bundle Size Optimization"}
 
 
+def test_public_model_exports_remain_compatible():
+    from refactor_bot.models.report_models import RefactorRule as LegacyRefactorRule
+    from refactor_bot.models.skill_models import RefactorRule as CoreRefactorRule
+    from refactor_bot.models import RefactorRule as PackageRefactorRule
+    from refactor_bot.models import SkillMetadata
+
+    assert LegacyRefactorRule is CoreRefactorRule
+    assert PackageRefactorRule is CoreRefactorRule
+    assert isinstance(SkillMetadata(name="x", version="1", description="y", impact_levels=["LOW"], categories=["c"], triggers=["t"]), SkillMetadata)
+
+
 def test_vercel_skill_load_from_disk_uses_prompt_and_rules(tmp_path: Path):
     _reset_registry_state()
 


### PR DESCRIPTION
## Summary
Adds backward-compatible model exports and import-surface tests to reduce downstream breakage from the Skills migration.

## Changes
- `src/refactor_bot/models/report_models.py`
  - Adds backward-compatible `RefactorRule` and `SkillMetadata` aliases.
  - Adds stable `__all__` for model exports.
- `tests/test_skills.py`
  - Adds `test_public_model_exports_remain_compatible` to ensure:
    - `refactor_bot.models.report_models.RefactorRule` is the same object as `refactor_bot.models.skill_models.RefactorRule`.
    - package-level import remains consistent.
    - `SkillMetadata` is importable through `refactor_bot.models`.

## Validation
- New regression test covers import compatibility for downstream consumers.

## Risk
- This keeps compatibility but does not fully validate external clients that dynamically introspect class internals.

## Issue
- Closes #19


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves downstream RefactorRule model compatibility during the Skills migration. Adds stable re-exports and tests to keep public imports unchanged.

- **Refactors**
  - Re-export RefactorRule and SkillMetadata from report_models and define a stable __all__.
  - Add tests to assert RefactorRule identity across modules/package and that SkillMetadata remains importable.

<sup>Written for commit 53d937e0db24d972358370317d9d1a00a8b44b03. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

