### PR TITLE
test(skills): add mixed-topology activation regression tests

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -12,6 +12,12 @@ class DummyRepoIndex:
     is_react_project = False
 
 
+class DummyRepoTopology:
+    def __init__(self, is_react_project: bool = False, project_type: str | None = None):
+        self.is_react_project = is_react_project
+        self.project_type = project_type
+
+
 def _reset_registry_state():
     registry._skills = {}
     registry._active_skills = []
@@ -94,4 +100,30 @@ class TestSkillActivation:
             selected_skill_names=["vercel_react_best_practices"],
         )
         assert active
+        assert active[0].metadata.name == "vercel-react-best-practices"
+
+    def test_auto_activate_non_react_repo_without_directive_has_no_skills(self):
+        _reset_registry_state()
+        active = activate_skills_for_repo(
+            DummyRepoTopology(is_react_project=False, project_type=None),
+            directive="Refactor utility function",
+        )
+        assert active == []
+
+    def test_auto_activate_nextjs_repo_without_directive_activates_skill(self):
+        _reset_registry_state()
+        active = activate_skills_for_repo(
+            DummyRepoTopology(is_react_project=True, project_type="nextjs"),
+            directive="Refactor class component",
+        )
+        assert len(active) == 1
+        assert active[0].metadata.name == "vercel-react-best-practices"
+
+    def test_auto_activate_react_keyword_overrides_non_react_index(self):
+        _reset_registry_state()
+        active = activate_skills_for_repo(
+            DummyRepoTopology(is_react_project=False, project_type=None),
+            directive="Optimize React rendering performance",
+        )
+        assert len(active) == 1
         assert active[0].metadata.name == "vercel-react-best-practices"


### PR DESCRIPTION
## Summary
Adds regression coverage for skill activation across differing repository topologies.

## Changes
- Added tests in `tests/test_skills.py` covering:
  - non-react repositories with no React keyword in directive (no auto-activation)
  - nextjs/react project indexer metadata triggers activation when directive is non-React-specific
  - explicit React keyword activation override on non-react index
  - explicit skill-name underscore normalization already covered in existing tests

## Validation
- New behavioral tests in `test_skills.py`:
  - `test_auto_activate_non_react_repo_without_directive_has_no_skills`
  - `test_auto_activate_nextjs_repo_without_directive_activates_skill`
  - `test_auto_activate_react_keyword_overrides_non_react_index`

## Issue
- Closes #20


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests for skill auto-activation across repo topologies (closes #20). Verifies no activation for non-React repos without directives, activation for Next.js/React repos with generic directives, and React keyword override on non-React indexes.

<sup>Written for commit b92cb9cfdf91e9b39ca719ba0f6da9c6f7932ed4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

