### PR TITLE
chore(skills): preserve RefactorRule model compatibility

### DIFF
--- a/src/refactor_bot/models/report_models.py
+++ b/src/refactor_bot/models/report_models.py
@@ -70,3 +70,20 @@ class TestReport(BaseModel):
     llm_analysis: str | None = None
     tested_at: datetime = Field(default_factory=datetime.now)
     low_trust_pass: bool = False
+
+
+# Backward-compatible model exports for downstream integrations.
+from refactor_bot.models.skill_models import RefactorRule as SkillRefactorRule, SkillMetadata
+
+RefactorRule = SkillRefactorRule
+
+__all__ = [
+    "AuditFinding",
+    "AuditReport",
+    "BreakingChange",
+    "FindingSeverity",
+    "TestReport",
+    "TestRunResult",
+    "RefactorRule",
+    "SkillMetadata",
+]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -149,3 +149,24 @@ class TestSkillActivation:
         )
         assert active
         assert active[0].metadata.name == "vercel-react-best-practices"
+
+
+def test_public_model_exports_remain_compatible():
+    from refactor_bot.models.report_models import RefactorRule as LegacyRefactorRule
+    from refactor_bot.models.skill_models import RefactorRule as CoreRefactorRule
+    from refactor_bot.models import RefactorRule as PackageRefactorRule
+    from refactor_bot.models import SkillMetadata
+
+    assert LegacyRefactorRule is CoreRefactorRule
+    assert PackageRefactorRule is CoreRefactorRule
+    assert isinstance(
+        SkillMetadata(
+            name="x",
+            version="1",
+            description="y",
+            impact_levels=["LOW"],
+            categories=["c"],
+            triggers=["t"],
+        ),
+        SkillMetadata,
+    )


### PR DESCRIPTION
## Summary\nReintroduces backward-compatible model exports after Skills migration refactor:\n- exports RefactorRule and SkillMetadata from report_models for downstream consumers\n- adds compatibility assertions in tests/test_skills.py\n\n## Issue\n- Closes #19\n

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves backward-compatible model exports so downstream imports keep working after the Skills migration. Re-exports RefactorRule and SkillMetadata from report_models and adds tests to confirm they match the core models and can be instantiated.

<sup>Written for commit f01ca5356dc243577aa085247a672aa07b081819. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

