### PR TITLE
chore(skills): preserve RefactorRule model compatibility

### DIFF
--- a/src/refactor_bot/models/report_models.py
+++ b/src/refactor_bot/models/report_models.py
@@ -70,3 +70,20 @@ class TestReport(BaseModel):
     llm_analysis: str | None = None
     tested_at: datetime = Field(default_factory=datetime.now)
     low_trust_pass: bool = False
+
+
+# Backward-compatible model exports for downstream integrations.
+from refactor_bot.models.skill_models import RefactorRule as SkillRefactorRule, SkillMetadata
+
+RefactorRule = SkillRefactorRule
+
+__all__ = [
+    "AuditFinding",
+    "AuditReport",
+    "BreakingChange",
+    "FindingSeverity",
+    "TestReport",
+    "TestRunResult",
+    "RefactorRule",
+    "SkillMetadata",
+]

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -149,3 +149,24 @@ class TestSkillActivation:
         )
         assert active
         assert active[0].metadata.name == "vercel-react-best-practices"
+
+
+def test_public_model_exports_remain_compatible():
+    from refactor_bot.models.report_models import RefactorRule as LegacyRefactorRule
+    from refactor_bot.models.skill_models import RefactorRule as CoreRefactorRule
+    from refactor_bot.models import RefactorRule as PackageRefactorRule
+    from refactor_bot.models import SkillMetadata
+
+    assert LegacyRefactorRule is CoreRefactorRule
+    assert PackageRefactorRule is CoreRefactorRule
+    assert isinstance(
+        SkillMetadata(
+            name="x",
+            version="1",
+            description="y",
+            impact_levels=["LOW"],
+            categories=["c"],
+            triggers=["t"],
+        ),
+        SkillMetadata,
+    )


### PR DESCRIPTION
## Summary\nReintroduces backward-compatible model exports after Skills migration refactor:\n- exports RefactorRule and SkillMetadata from report_models for downstream consumers\n- adds compatibility assertions in tests/test_skills.py\n\n## Issue\n- Closes #19\n\nNote: this replaces prior PR #23, which became non-mergeable after follow-up merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves downstream compatibility for RefactorRule after the Skills refactor. Re-exports models and adds tests so legacy import paths keep working.

- **Refactors**
  - Re-export RefactorRule and SkillMetadata from report_models via __all__.
  - Alias LegacyRefactorRule to the core SkillRefactorRule.
  - Add tests to verify legacy and package-root imports match the core model and SkillMetadata remains constructible.

<sup>Written for commit 5fdcfcc1248ba31e4ce6becc4be28b16b2c4aaf9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

