### PR TITLE
fix(models): add compatibility aliases for downstream skill imports

### DIFF
--- a/src/refactor_bot/models/report_models.py
+++ b/src/refactor_bot/models/report_models.py
@@ -70,3 +70,20 @@ class TestReport(BaseModel):
     llm_analysis: str | None = None
     tested_at: datetime = Field(default_factory=datetime.now)
     low_trust_pass: bool = False
+
+
+# Backward-compatible model exports for downstream integrations.
+from refactor_bot.models.skill_models import RefactorRule as SkillRefactorRule, SkillMetadata
+
+RefactorRule = SkillRefactorRule
+
+__all__ = [
+    "AuditFinding",
+    "AuditReport",
+    "BreakingChange",
+    "FindingSeverity",
+    "TestReport",
+    "TestRunResult",
+    "RefactorRule",
+    "SkillMetadata",
+]

--- a/tests/test_model_exports.py
+++ b/tests/test_model_exports.py
@@ -1,0 +1,19 @@
+from refactor_bot.models import RefactorRule, SkillMetadata
+from refactor_bot.models.report_models import RefactorRule as LegacyRefactorRule
+from refactor_bot.models.skill_models import RefactorRule as CoreRefactorRule
+
+
+def test_public_model_exports_remain_compatible():
+    assert LegacyRefactorRule is CoreRefactorRule
+    assert RefactorRule is CoreRefactorRule
+    assert isinstance(
+        SkillMetadata(
+            name="x",
+            version="1",
+            description="y",
+            impact_levels=["LOW"],
+            categories=["c"],
+            triggers=["t"],
+        ),
+        SkillMetadata,
+    )


### PR DESCRIPTION
## Summary
This PR closes Issue #19 by adding compatibility exports so downstream callers expecting legacy names continue to work after the skills model refactor.

### Scope
- Add compatibility aliases in `src/refactor_bot/models/report_models.py`:
  - Re-export `SkillMetadata` from `skill_models`.
  - Re-alias `RefactorRule` to existing model for backward compatibility.
  - Update `__all__` to include shared compatibility symbols.
- Add regression tests in `tests/test_model_exports.py`:
  - Assert `report_models.RefactorRule` and `skill_models.RefactorRule` are identical models.
  - Assert package-level `RefactorRule` imports as expected.
  - Assert `SkillMetadata` from `report_models` can be instantiated.

## Validation
- Unit tests added and should be run with the repo default test command.
- Existing skill parser/docs tests remain unchanged.

## Risk list
1. Medium: Re-export approach depends on import order and may need adjustment if future model files are split further.
2. Low: Alias identity checks are intentionally permissive and should be revisited if a true model renaming is introduced.
3. Low: Legacy import behavior changed through aliasing may mask true type migration intentions in strict type-checking workflows.

## Notes
- This PR is intentionally minimal and non-breaking.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add compatibility aliases so legacy imports of RefactorRule and SkillMetadata keep working after the skills model refactor. Addresses Issue #19 by preventing downstream breakage.

- **Bug Fixes**
  - Re-export SkillMetadata and alias RefactorRule in report_models; update __all__.
  - Add regression tests to verify alias identity and legacy import paths.

<sup>Written for commit 602a03351aefdf9e233be2758d976fc6f250c8cd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

