### PR TITLE
test(skills): align parser test with fallback behavior

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -38,10 +38,10 @@ def test_vercel_rules_parser_reads_quick_reference(tmp_path: Path):
     )
 
     parsed = rules.get_rules(skill_markdown)
-    assert len(parsed) == 2
     rule_ids = {r.rule_id for r in parsed}
-    assert rule_ids == {"async-parallel", "bundle-barrel-imports"}
-    assert parsed[0].category in {"Eliminating Waterfalls", "Bundle Size Optimization"}
+    assert {"async-parallel", "bundle-barrel-imports"}.issubset(rule_ids)
+    assert len(parsed) >= 2
+    assert parsed[0].rule_id in {"async-parallel", "bundle-barrel-imports"}
 
 
 def test_vercel_rules_parser_handles_flexible_markup(tmp_path: Path):


### PR DESCRIPTION
# Summary
The parser now returns parsed skill + fallback catalog rules, so this test should assert inclusion rather than exact count.

## Validation
- ============================= test session starts ==============================
platform darwin -- Python 3.12.5, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/michaellydick/dev/Multi-Agent_RAG_Refactor_Bot
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.3, cov-7.0.0
collected 1 item

tests/test_skills.py .                                                   [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.5-final-0 _______________

Name                                                              Stmts   Miss  Cover
-------------------------------------------------------------------------------------
src/refactor_bot/__init__.py                                          1      0   100%
src/refactor_bot/agents/__init__.py                                   7      0   100%
src/refactor_bot/agents/consistency_auditor.py                      203    182    10%
src/refactor_bot/agents/exceptions.py                                10      0   100%
src/refactor_bot/agents/planner.py                                  239    203    15%
src/refactor_bot/agents/refactor_executor.py                        242    209    14%
src/refactor_bot/agents/repo_indexer.py                             135    121    10%
src/refactor_bot/agents/test_validator.py                           209    174    17%
src/refactor_bot/cli/__init__.py                                      2      2     0%
src/refactor_bot/cli/__main__.py                                      4      4     0%
src/refactor_bot/cli/main.py                                        162    162     0%
src/refactor_bot/models/__init__.py                                   6      0   100%
src/refactor_bot/models/diff_models.py                               10      0   100%
src/refactor_bot/models/report_models.py                             54      0   100%
src/refactor_bot/models/schemas.py                                   71      0   100%
src/refactor_bot/models/skill_models.py                              15      0   100%
src/refactor_bot/models/task_models.py                               17      0   100%
src/refactor_bot/orchestrator/__init__.py                             4      4     0%
src/refactor_bot/orchestrator/exceptions.py                           2      2     0%
src/refactor_bot/orchestrator/graph.py                              202    202     0%
src/refactor_bot/orchestrator/recovery.py                            34     34     0%
src/refactor_bot/orchestrator/state.py                               23     23     0%
src/refactor_bot/rag/__init__.py                                      5      5     0%
src/refactor_bot/rag/embeddings.py                                   39     39     0%
src/refactor_bot/rag/exceptions.py                                    4      4     0%
src/refactor_bot/rag/retriever.py                                    72     72     0%
src/refactor_bot/rag/vector_store.py                                 70     70     0%
src/refactor_bot/rules/__init__.py                                    3      0   100%
src/refactor_bot/rules/react_rules.py                                 2      0   100%
src/refactor_bot/rules/rule_engine.py                                22     13    41%
src/refactor_bot/skills/__init__.py                                   3      0   100%
src/refactor_bot/skills/base.py                                      13      0   100%
src/refactor_bot/skills/manager.py                                   12      9    25%
src/refactor_bot/skills/registry.py                                  71     42    41%
src/refactor_bot/skills/vercel_react_best_practices/__init__.py       2      0   100%
src/refactor_bot/skills/vercel_react_best_practices/rules.py         74     10    86%
src/refactor_bot/skills/vercel_react_best_practices/skill.py         42     26    38%
src/refactor_bot/utils/__init__.py                                    2      0   100%
src/refactor_bot/utils/ast_parser.py                                179    159    11%
src/refactor_bot/utils/diff_generator.py                             69     62    10%
-------------------------------------------------------------------------------------
TOTAL                                                              2336   1833    22%
============================== 1 passed in 0.35s ===============================
- ============================= test session starts ==============================
platform darwin -- Python 3.12.5, pytest-9.0.2, pluggy-1.6.0
rootdir: /Users/michaellydick/dev/Multi-Agent_RAG_Refactor_Bot
configfile: pyproject.toml
plugins: anyio-4.12.1, langsmith-0.7.3, cov-7.0.0
collected 94 items

tests/test_cli.py ...........................                            [ 28%]
tests/test_planner.py ...................................                [ 65%]
tests/test_refactor_executor.py .....................                    [ 88%]
tests/test_skills.py ...........                                         [100%]

================================ tests coverage ================================
_______________ coverage: platform darwin, python 3.12.5-final-0 _______________

Name                                                              Stmts   Miss  Cover
-------------------------------------------------------------------------------------
src/refactor_bot/__init__.py                                          1      0   100%
src/refactor_bot/agents/__init__.py                                   7      0   100%
src/refactor_bot/agents/consistency_auditor.py                      203    182    10%
src/refactor_bot/agents/exceptions.py                                10      0   100%
src/refactor_bot/agents/planner.py                                  239     50    79%
src/refactor_bot/agents/refactor_executor.py                        242     55    77%
src/refactor_bot/agents/repo_indexer.py                             135    121    10%
src/refactor_bot/agents/test_validator.py                           209    174    17%
src/refactor_bot/cli/__init__.py                                      2      0   100%
src/refactor_bot/cli/__main__.py                                      4      4     0%
src/refactor_bot/cli/main.py                                        162     16    90%
src/refactor_bot/models/__init__.py                                   6      0   100%
src/refactor_bot/models/diff_models.py                               10      0   100%
src/refactor_bot/models/report_models.py                             54      0   100%
src/refactor_bot/models/schemas.py                                   71      0   100%
src/refactor_bot/models/skill_models.py                              15      0   100%
src/refactor_bot/models/task_models.py                               17      0   100%
src/refactor_bot/orchestrator/__init__.py                             4      0   100%
src/refactor_bot/orchestrator/exceptions.py                           2      0   100%
src/refactor_bot/orchestrator/graph.py                              202    174    14%
src/refactor_bot/orchestrator/recovery.py                            34     26    24%
src/refactor_bot/orchestrator/state.py                               23      0   100%
src/refactor_bot/rag/__init__.py                                      5      0   100%
src/refactor_bot/rag/embeddings.py                                   39     29    26%
src/refactor_bot/rag/exceptions.py                                    4      0   100%
src/refactor_bot/rag/retriever.py                                    72     62    14%
src/refactor_bot/rag/vector_store.py                                 70     56    20%
src/refactor_bot/rules/__init__.py                                    3      0   100%
src/refactor_bot/rules/react_rules.py                                 2      0   100%
src/refactor_bot/rules/rule_engine.py                                22      1    95%
src/refactor_bot/skills/__init__.py                                   3      0   100%
src/refactor_bot/skills/base.py                                      13      0   100%
src/refactor_bot/skills/manager.py                                   12      0   100%
src/refactor_bot/skills/registry.py                                  71      7    90%
src/refactor_bot/skills/vercel_react_best_practices/__init__.py       2      0   100%
src/refactor_bot/skills/vercel_react_best_practices/rules.py         74      3    96%
src/refactor_bot/skills/vercel_react_best_practices/skill.py         42      5    88%
src/refactor_bot/utils/__init__.py                                    2      0   100%
src/refactor_bot/utils/ast_parser.py                                179    159    11%
src/refactor_bot/utils/diff_generator.py                             69      8    88%
-------------------------------------------------------------------------------------
TOTAL                                                              2336   1132    52%
============================== 94 passed in 6.32s ==============================

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated skills parser test to account for fallback catalog rules in the parsed output. The test now asserts expected rule IDs as a subset, enforces a minimum count, and checks rule_id instead of category to avoid brittle expectations.

<sup>Written for commit ae68fa617d4571c0f8e034136924b9082d0032cf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

