### PR TITLE
docs: add PR artifact JSON-first compatibility guidance

### DIFF
--- a/docs/PR_ARTIFACT_SCHEMA.md
+++ b/docs/PR_ARTIFACT_SCHEMA.md
@@ -57,3 +57,10 @@ If any restore action reports a conflict, treat it as a manual merge task:
 
 1. `git status`
 2. resolve conflicts manually
+
+## Compatibility notes
+
+- JSON remains the default artifact format (`--output-pr-artifact-format json`).
+- Markdown is an explicit opt-in variant for humans/PR workflows.
+- Existing JSON parsers should continue to work as the JSON payload remains a single
+  top-level object with additive-only schema fields.


### PR DESCRIPTION
Small docs update clarifying that JSON artifact output is default and markdown is opt-in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies PR artifact format guidance: JSON is the default output and Markdown is an opt-in human-readable variant. Confirms the JSON payload stays a single top-level object with additive-only fields, so existing parsers continue to work without changes.

<sup>Written for commit a8cbbb9003949ee4de43dc947b0177b6cbf8547e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

